### PR TITLE
Fix namespace issue and property typo

### DIFF
--- a/JM QR Code Data Example/DNRecord.cs
+++ b/JM QR Code Data Example/DNRecord.cs
@@ -1,114 +1,116 @@
-﻿using JM.Tools;
 using System;
 using System.Collections.Generic;
 
-/// <summary>
-/// Represents a delivery note record containing all relevant information 
-/// about a delivery, including customer and delivery addresses, contact details,
-/// and information about delivered items.
-/// </summary>
-[Serializable]
-public class DNRecord
+namespace JM.Tools
 {
     /// <summary>
-    /// Unique delivery note number for identifying the delivery note.
+    /// Represents a delivery note record containing all relevant information
+    /// about a delivery, including customer and delivery addresses, contact details,
+    /// and information about delivered items.
     /// </summary>
-    public int DeliveryNoteNo { get; set; }
+    [Serializable]
+    public class DNRecord
+    {
+        /// <summary>
+        /// Unique delivery note number for identifying the delivery note.
+        /// </summary>
+        public int DeliveryNoteNo { get; set; }
 
-    #region Customer Address
+        #region Customer Address
 
-    /// <summary>
-    /// Name of the customer.
-    /// </summary>
-    public string CustomerName { get; set; }
+        /// <summary>
+        /// Name of the customer.
+        /// </summary>
+        public string CustomerName { get; set; }
 
-    /// <summary>
-    /// Street and house number of the customer.
-    /// </summary>
-    public string CustomerStreet { get; set; }
+        /// <summary>
+        /// Street and house number of the customer.
+        /// </summary>
+        public string CustomerStreet { get; set; }
 
-    /// <summary>
-    /// Country of the customer.
-    /// </summary>
-    public string CustomerCountry { get; set; }
+        /// <summary>
+        /// Country of the customer.
+        /// </summary>
+        public string CustomerCountry { get; set; }
 
-    /// <summary>
-    /// Postal code of the customer.
-    /// </summary>
-    public string CustomerZipcode { get; set; }
+        /// <summary>
+        /// Postal code of the customer.
+        /// </summary>
+        public string CustomerZipcode { get; set; }
 
-    /// <summary>
-    /// City of the customer.
-    /// </summary>
-    public string CustomerCity { get; set; }
+        /// <summary>
+        /// City of the customer.
+        /// </summary>
+        public string CustomerCity { get; set; }
 
-    #endregion
+        #endregion
 
-    #region Delivery Address
+        #region Delivery Address
 
-    /// <summary>
-    /// Name of the delivery recipient (may differ from customer).
-    /// </summary>
-    public string DeliveryName { get; set; }
+        /// <summary>
+        /// Name of the delivery recipient (may differ from customer).
+        /// </summary>
+        public string DeliveryName { get; set; }
 
-    /// <summary>
-    /// Street and house number of the delivery address.
-    /// </summary>
-    public string DeliveryStreet { get; set; }
+        /// <summary>
+        /// Street and house number of the delivery address.
+        /// </summary>
+        public string DeliveryStreet { get; set; }
 
-    /// <summary>
-    /// Country of the delivery address.
-    /// </summary>
-    public string DeliveryCountry { get; set; }
+        /// <summary>
+        /// Country of the delivery address.
+        /// </summary>
+        public string DeliveryCountry { get; set; }
 
-    /// <summary>
-    /// Postal code of the delivery address.
-    /// </summary>
-    public string DeliveryZipcode { get; set; }
+        /// <summary>
+        /// Postal code of the delivery address.
+        /// </summary>
+        public string DeliveryZipcode { get; set; }
 
-    /// <summary>
-    /// City of the delivery address.
-    /// </summary>
-    public string DeliveryCity { get; set; }
+        /// <summary>
+        /// City of the delivery address.
+        /// </summary>
+        public string DeliveryCity { get; set; }
 
-    #endregion
+        #endregion
 
-    #region Contact Information
+        #region Contact Information
 
-    /// <summary>
-    /// Name of the contact person for this delivery.
-    /// </summary>
-    public string ContactName { get; set; }
+        /// <summary>
+        /// Name of the contact person for this delivery.
+        /// </summary>
+        public string ContactName { get; set; }
 
-    /// <summary>
-    /// Phone number of the contact person.
-    /// </summary>
-    public string ContactPhone { get; set; }
+        /// <summary>
+        /// Phone number of the contact person.
+        /// </summary>
+        public string ContactPhone { get; set; }
 
-    /// <summary>
-    /// Email address of the contact person.
-    /// </summary>
-    public string ContactMail { get; set; }
+        /// <summary>
+        /// Email address of the contact person.
+        /// </summary>
+        public string ContactMail { get; set; }
 
-    #endregion
+        #endregion
 
-    #region Delivery Details
+        #region Delivery Details
 
-    /// <summary>
-    /// Total number of delivered pieces/items.
-    /// </summary>
-    public int PieceCount { get; set; }
+        /// <summary>
+        /// Total number of delivered pieces/items.
+        /// </summary>
+        public int PieceCount { get; set; }
 
-    /// <summary>
-    /// Total weight of the delivery in the respective weight unit.
-    /// </summary>
-    public double TotalWeight { get; set; }
+        /// <summary>
+        /// Total weight of the delivery in the respective weight unit.
+        /// </summary>
+        public double TotalWeight { get; set; }
 
-    /// <summary>
-    /// List of all individual items/positions of the delivery.
-    /// Each element contains detailed information about a delivered item.
-    /// </summary>
-    public List<PieceRecord> Pieces { get; set; }
+        /// <summary>
+        /// List of all individual items/positions of the delivery.
+        /// Each element contains detailed information about a delivered item.
+        /// </summary>
+        public List<PieceRecord> Pieces { get; set; }
 
-    #endregion
+        #endregion
+    }
 }

--- a/JM QR Code Data Example/PieceRecord.cs
+++ b/JM QR Code Data Example/PieceRecord.cs
@@ -134,7 +134,7 @@ namespace JM.Tools
         /// <summary>
         /// Width measurement of the piece.
         /// </summary>
-        public decimal? Witdh { get; set; }
+        public decimal? Width { get; set; }
 
         /// <summary>
         /// Quality grade or classification of the piece.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ public class PieceRecord {
     public decimal? WeightNet { get; set; }
     public decimal? WeightRM { get; set; }
     public decimal? WeightM2 { get; set; }
-    public decimal? Witdh { get; set; }
+    public decimal? Width { get; set; }
     public string Quality { get; set; }
     public decimal? BrutFeet { get; set; }
     public decimal? AllowanceFeet { get; set; }


### PR DESCRIPTION
## Summary
- wrap `DNRecord` in `JM.Tools` namespace
- rename `PieceRecord.Witdh` property to `Width`
- update README accordingly

## Testing
- `dotnet build 'JM QR Code Data Example/JM QR Code Data Example.csproj'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847d2a04698832cb1b8d92fcb1f3a4b